### PR TITLE
Fixed a console.log that escaped its way to prod

### DIFF
--- a/src/context/stateContext.js
+++ b/src/context/stateContext.js
@@ -63,7 +63,6 @@ export default function StateContext({ children }) {
       setAmount("");
       setList([...list, newItems]);
       setIsEditing(false);
-      console.log(list);
     }
   };
 


### PR DESCRIPTION
I noticed this while going through your code when in search of an ERP system